### PR TITLE
Handle location().hash being an empty string.

### DIFF
--- a/core/src/main/java/router/fu/HashBackend.java
+++ b/core/src/main/java/router/fu/HashBackend.java
@@ -38,7 +38,8 @@ public class HashBackend
   @Override
   public String getLocation()
   {
-    return _window.location().hash.substring( 1 );
+    final String hash = _window.location().hash;
+    return 0 == hash.length() ? "" : hash.substring( 1 );
   }
 
   @Override


### PR DESCRIPTION
GWT emulation of Java 1.8 String.substring() swallowed this quietly. 
Combination of gwt 2.10 and Java 17 fails precondition checks.