### PR TITLE
[codex] Adopt Proton shared processor helpers

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -32,7 +32,7 @@ artifacts:
   guava: com.google.guava:guava:jar:27.1-jre
   guava_failureaccess: com.google.guava:failureaccess:jar:1.0.1
 
-  proton_core: org.realityforge.proton:proton-core:jar:0.73-SNAPSHOT
-  proton_qa: org.realityforge.proton:proton-qa:jar:0.73-SNAPSHOT
+  proton_core: org.realityforge.proton:proton-core:jar:0.74
+  proton_qa: org.realityforge.proton:proton-qa:jar:0.74
 
   javax_json: org.glassfish:javax.json:jar:1.1

--- a/build.yaml
+++ b/build.yaml
@@ -32,7 +32,7 @@ artifacts:
   guava: com.google.guava:guava:jar:27.1-jre
   guava_failureaccess: com.google.guava:failureaccess:jar:1.0.1
 
-  proton_core: org.realityforge.proton:proton-core:jar:0.72
-  proton_qa: org.realityforge.proton:proton-qa:jar:0.72
+  proton_core: org.realityforge.proton:proton-core:jar:0.73-SNAPSHOT
+  proton_qa: org.realityforge.proton:proton-qa:jar:0.73-SNAPSHOT
 
   javax_json: org.glassfish:javax.json:jar:1.1

--- a/processor/src/main/java/router/fu/processor/RouterDescriptor.java
+++ b/processor/src/main/java/router/fu/processor/RouterDescriptor.java
@@ -6,15 +6,14 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
-import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
-import javax.lang.model.element.NestingKind;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
+import org.realityforge.proton.ElementsUtil;
 import org.realityforge.proton.GeneratorUtil;
+import org.realityforge.proton.MemberChecks;
 import org.realityforge.proton.ProcessorException;
 
 final class RouterDescriptor
@@ -34,28 +33,12 @@ final class RouterDescriptor
     _packageElement = Objects.requireNonNull( packageElement );
     _element = Objects.requireNonNull( element );
 
-    if ( ElementKind.CLASS != element.getKind() )
-    {
-      throw new ProcessorException( "@Router target must be a class", element );
-    }
-    else if ( element.getModifiers().contains( Modifier.ABSTRACT ) )
-    {
-      throw new ProcessorException( "@Router target must not be abstract", element );
-    }
-    else if ( element.getModifiers().contains( Modifier.FINAL ) )
-    {
-      throw new ProcessorException( "@Router target must not be final", element );
-    }
-    else if ( NestingKind.TOP_LEVEL != element.getNestingKind() &&
-              !element.getModifiers().contains( Modifier.STATIC ) )
-    {
-      throw new ProcessorException( "@Router target must not be a non-static nested class", element );
-    }
+    MemberChecks.mustBeClass( Constants.ROUTER_ANNOTATION_CLASSNAME, element );
+    MemberChecks.mustNotBeAbstract( Constants.ROUTER_ANNOTATION_CLASSNAME, element );
+    MemberChecks.mustNotBeFinal( Constants.ROUTER_ANNOTATION_CLASSNAME, element );
+    MemberChecks.mustNotBeNonStaticNestedType( Constants.ROUTER_ANNOTATION_CLASSNAME, element );
 
-    final List<ExecutableElement> constructors = element.getEnclosedElements().stream().
-      filter( m -> m.getKind() == ElementKind.CONSTRUCTOR ).
-      map( m -> (ExecutableElement) m ).
-      collect( Collectors.toList() );
+    final List<ExecutableElement> constructors = ElementsUtil.getConstructors( element );
     if ( !( 1 == constructors.size() &&
             constructors.get( 0 ).getParameters().isEmpty() &&
             !constructors.get( 0 ).getModifiers().contains( Modifier.PRIVATE ) ) )

--- a/processor/src/main/java/router/fu/processor/RouterProcessor.java
+++ b/processor/src/main/java/router/fu/processor/RouterProcessor.java
@@ -31,6 +31,7 @@ import org.realityforge.proton.AnnotationsUtil;
 import org.realityforge.proton.DeferredElementSet;
 import org.realityforge.proton.ElementsUtil;
 import org.realityforge.proton.MemberChecks;
+import org.realityforge.proton.NamesUtil;
 import org.realityforge.proton.ProcessorException;
 import org.realityforge.proton.StopWatch;
 
@@ -544,23 +545,6 @@ public final class RouterProcessor
   private String deriveCallbackName( @Nonnull final ExecutableElement method, @Nonnull final String name )
     throws ProcessorException
   {
-    if ( name.isEmpty() )
-    {
-      final String methodName = method.getSimpleName().toString();
-      final Matcher matcher = RouterProcessor.CALLBACK_PATTERN.matcher( methodName );
-      if ( matcher.find() )
-      {
-        final String candidate = matcher.group( 1 );
-        return Character.toLowerCase( candidate.charAt( 0 ) ) + candidate.substring( 1 );
-      }
-      else
-      {
-        return null;
-      }
-    }
-    else
-    {
-      return name;
-    }
+    return NamesUtil.deriveName( method, CALLBACK_PATTERN, name, "" );
   }
 }


### PR DESCRIPTION
## Summary
- Update Proton dependencies to the released `0.74` artifacts.
- Adopt shared Proton helper APIs in the Router-Fu processor where they preserve existing behavior.

## Validation
- `bundle exec buildr router-fu:processor:compile router-fu:processor:test`

Local run evidence:
- Command completed successfully against `proton-core`/`proton-qa` `0.74` in 18.716s.
- `router-fu-processor`: 68/68, failures 0, skips 0.
- `router-fu-core`: 28/28, failures 0, skips 0.
